### PR TITLE
Add random color hover function

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,20 +9,32 @@ function draw(rows, cols) {
         // cell.innerText = (i + 1);
         container.appendChild(cell).className = "cell";
     }
-    makeRed();
+    // makeBlue();
+    randomColor();
 }
 
 draw(16, 16);
 
-// a function that turns the element being hovered on red
-function makeRed () {
+
+// a function that turns the element being hovered over a random color
+function randomColor () {
     let items = document.querySelectorAll(".cell");
     items.forEach(item => {
         item.addEventListener("mouseover", () => {
-            item.style.backgroundColor = "blue";
+            item.style.backgroundColor = `rgb(${Math.floor(Math.random() * 256)},${Math.floor(Math.random() * 256)},${Math.floor(Math.random() * 256)})`;
         });
     });
 }
+
+// a function that turns the element being hovered on blue
+// function makeBlue () {
+//     let items = document.querySelectorAll(".cell");
+//     items.forEach(item => {
+//         item.addEventListener("mouseover", () => {
+//             item.style.backgroundColor = "blue";
+//         });
+//     });
+// }
 
 const button = document.getElementById("reset");
 


### PR DESCRIPTION
A blue hover effect is replaced with a random color hover effect. This was done by setting the item's background color to a string literal RGB value. Earlier, I struggled with making the random RGB functional by trying to set a variable equal to a random number. However, that only set the RGB value to one static value instead of randomizing every pass through, which the string literal achieves.